### PR TITLE
Feat: Add scalar_type=scalar|row|column|row_column

### DIFF
--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -94,6 +94,12 @@ def create_network(
     scalar_init_value = kwargs.get("scalar_init_value", None)
     if scalar_init_value is not None:
         scalar_init_value = float(scalar_init_value)
+    scalar_type = kwargs.get("scalar_type", "scalar")
+    if scalar_type not in ("scalar", "row", "column", "row_column"):
+        raise ValueError(
+            f"Invalid scalar_type='{scalar_type}', must be one of: "
+            f"scalar, row, column, row_column"
+        )
     block_size = int(kwargs.get("block_size", 4) or 4)
     train_norm = str_bool(kwargs.get("train_norm", False))
     constraint = float(kwargs.get("constraint", 0.0) or 0.0)
@@ -331,6 +337,7 @@ def create_network(
                 "use_scalar set to False."
             )
             use_scalar = False
+            scalar_type = "scalar"
 
     # RaLoRA parameters (Kohya path)
     ralora_n_max = int(kwargs.get("ralora_n_max", 32))
@@ -380,6 +387,7 @@ def create_network(
                 "use_scalar set to False."
             )
             use_scalar = False
+            scalar_type = "scalar"
 
     # LoRA² parameters (Kohya path)
     lora2_nu_init = kwargs.get("lora2_nu_init", None)
@@ -416,6 +424,7 @@ def create_network(
         use_tucker=use_tucker,
         use_scalar=use_scalar,
         scalar_init_value=scalar_init_value,
+        scalar_type=scalar_type,
         network_module=algo,
         train_norm=train_norm,
         decompose_both=kwargs.get("decompose_both", False),

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -72,6 +72,7 @@ class LoConModule(LycorisBaseModule):
         olora_lambda: float = 0.5,
         olora_task_id: int = 0,
         use_timestep_mask: bool = False,
+        scalar_type: str = "scalar",
         **kwargs,
     ):
         """if alpha == 0 or None, alpha is rank (no scaling)."""
@@ -208,11 +209,31 @@ class LoConModule(LycorisBaseModule):
         self.register_buffer("alpha", torch.tensor(alpha * (lora_dim / r_factor)))
 
         if use_scalar:
-            init_val = scalar_init_value if scalar_init_value is not None else 0.1
-            self.scalar = nn.Parameter(torch.tensor(init_val))
-            if self.olora:
-                self.lora_scalar_list.append(self.scalar)
+            # O-LoRA only supports scalar_type="scalar"
+            if self.olora and scalar_type != "scalar":
+                logger.warning(
+                    f"O-LoRA: scalar_type='{scalar_type}' is not supported. "
+                    f"Falling back to scalar_type='scalar'."
+                )
+                scalar_type = "scalar"
+            self.scalar_type = scalar_type
+            if scalar_type == "scalar":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.scalar = nn.Parameter(torch.tensor(init_val))
+                if self.olora:
+                    self.lora_scalar_list.append(self.scalar)
+            elif scalar_type == "row":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.row_scalar = nn.Parameter(torch.full((self.shape[0],), init_val))
+            elif scalar_type == "column":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.col_scalar = nn.Parameter(torch.full((self.shape[1],), init_val))
+            elif scalar_type == "row_column":
+                init_val = scalar_init_value if scalar_init_value is not None else math.sqrt(0.1)
+                self.row_scalar = nn.Parameter(torch.full((self.shape[0],), init_val))
+                self.col_scalar = nn.Parameter(torch.full((self.shape[1],), init_val))
         else:
+            self.scalar_type = "none"
             self.register_buffer("scalar", torch.tensor(1.0), persistent=False)
 
         # Weight initialization
@@ -482,14 +503,14 @@ class LoConModule(LycorisBaseModule):
         missing_keys = incompatible_keys.missing_keys
         # Filter expected missing keys in O(n) instead of O(n²)
         missing_keys[:] = [k for k in missing_keys if not self._should_skip_missing_key(k)]
-        if isinstance(self.scalar, nn.Parameter):
-            self.scalar.data.copy_(torch.ones_like(self.scalar))
-        elif getattr(self, "scalar", None) is not None:
-            self.scalar.copy_(torch.ones_like(self.scalar))
-        else:
-            self.register_buffer(
-                "scalar", torch.ones_like(self.scalar), persistent=False
-            )
+        # Reset scalars to 1.0 (baked into weights during save)
+        for attr in ("scalar", "row_scalar", "col_scalar"):
+            param = getattr(self, attr, None)
+            if param is not None:
+                if isinstance(param, nn.Parameter):
+                    param.data.copy_(torch.ones_like(param))
+                else:
+                    param.copy_(torch.ones_like(param))
         # Initialize PiSSA buffers if not loaded from state dict
         if not hasattr(self, "pissa_A_init") or self.pissa_A_init is None:
             self.pissa_A_init = None
@@ -533,6 +554,34 @@ class LoConModule(LycorisBaseModule):
             return self._orthogonalize(weight)
         return weight
 
+    def _apply_scalar(self, weight, device=None, dtype=None):
+        """Apply the appropriate scalar (single, row, col, or row+col) to weight."""
+        if self.scalar_type == "scalar":
+            return weight * self.scalar.to(device=device, dtype=dtype)
+        elif self.scalar_type == "row":
+            return weight * self.row_scalar.to(device=device, dtype=dtype).view(-1, *([1] * (weight.dim() - 1)))
+        elif self.scalar_type == "column":
+            return weight * self.col_scalar.to(device=device, dtype=dtype).view(1, -1, *([1] * (weight.dim() - 2)))
+        elif self.scalar_type == "row_column":
+            r = self.row_scalar.to(device=device, dtype=dtype).view(-1, *([1] * (weight.dim() - 1)))
+            c = self.col_scalar.to(device=device, dtype=dtype).view(1, -1, *([1] * (weight.dim() - 2)))
+            return weight * r * c
+        return weight
+
+    def _apply_row_scalar(self, weight):
+        """Bake row scalar into weight for saving. For scalar type, bakes the single scalar."""
+        if self.scalar_type == "scalar":
+            return weight * self.scalar.to(device=weight.device, non_blocking=True)
+        elif self.scalar_type in ("row", "row_column"):
+            return weight * self.row_scalar.to(device=weight.device, non_blocking=True).view(-1, *([1] * (weight.dim() - 1)))
+        return weight
+
+    def _apply_col_scalar(self, weight):
+        """Bake col scalar into weight for saving."""
+        if self.scalar_type in ("column", "row_column"):
+            return weight * self.col_scalar.to(device=weight.device, non_blocking=True).view(1, -1, *([1] * (weight.dim() - 2)))
+        return weight
+
     def make_weight(self, device=None):
         if self.olora:
             return self._make_weight_multitask(device)
@@ -558,7 +607,7 @@ class LoConModule(LycorisBaseModule):
         weight = weight.view(self.shape)
         weight = self._apply_rank_dropout(weight, device)
 
-        return weight * self.scalar.to(device)
+        return self._apply_scalar(weight, device)
 
     def _make_weight_multitask(self, device=None):
         """Multi-task O-LoRA weight: sum of w_a @ w_b across all tasks."""
@@ -605,7 +654,7 @@ class LoConModule(LycorisBaseModule):
 
         # Cast scalar to target device+dtype once to avoid implicit fp32 upcast then
         # downcast back to dtype on every forward pass.
-        diff_weight = (diff_weight * self.scalar.to(device=device, dtype=dtype)) * self.scale
+        diff_weight = self._apply_scalar(diff_weight, device=device, dtype=dtype) * self.scale
         return diff_weight
 
     def _compute_diff_weight_multitask(self, device, dtype):
@@ -798,16 +847,15 @@ class LoConModule(LycorisBaseModule):
         if self.is_pissa and self.pissa_convert and self.pissa_A_init is not None:
             # PiSSA→LoRA conversion on save:
             # ΔW = A'B' - A₀B₀ = [A' | A₀] · [B' | -B₀]^T
-            lora_up_w = self.lora_up.weight * self.scalar.to(
-                device=self.lora_up.weight.device, non_blocking=True
-            )
+            lora_up_w = self._apply_row_scalar(self.lora_up.weight)
             # Concatenate: trained A (up) with initial A₀ (up init)
             converted_up = torch.cat(
                 [lora_up_w, self.pissa_A_init.to(lora_up_w.device)], dim=1
             )
             # Concatenate: trained B (down) with negated initial B₀ (down init)
+            lora_down_w = self._apply_col_scalar(self.lora_down.weight)
             converted_down = torch.cat(
-                [self.lora_down.weight, -self.pissa_B_init.to(self.lora_down.weight.device)], dim=0
+                [lora_down_w, -self.pissa_B_init.to(lora_down_w.device)], dim=0
             )
             destination["lora_up.weight"] = converted_up
             destination["lora_down.weight"] = converted_down
@@ -817,10 +865,8 @@ class LoConModule(LycorisBaseModule):
                 f"(rank {self.lora_dim} → {2 * self.lora_dim})"
             )
         else:
-            destination["lora_up.weight"] = self.lora_up.weight * self.scalar.to(
-                device=self.lora_up.weight.device, non_blocking=True
-            )
-            destination["lora_down.weight"] = self.lora_down.weight
+            destination["lora_up.weight"] = self._apply_row_scalar(self.lora_up.weight)
+            destination["lora_down.weight"] = self._apply_col_scalar(self.lora_down.weight)
             # Preserve PiSSA init weights in state dict for round-trip loading
             if self.is_pissa and self.pissa_A_init is not None:
                 destination["pissa_A_init"] = self.pissa_A_init
@@ -854,11 +900,8 @@ class LoConModule(LycorisBaseModule):
         # Compute portable LoRA weights.
         # Bake scalar into lora_up before concatenation so the converted
         # adapter produces  scalar*A'B' - A₀B₀  (matching custom_state_dict).
-        scalar_val = self.scalar.to(
-            device=self.lora_up.weight.device, non_blocking=True
-        )
-        lora_up_curr = self.lora_up.weight.data.clone() * scalar_val
-        lora_down_curr = self.lora_down.weight.data.clone()
+        lora_up_curr = self._apply_row_scalar(self.lora_up.weight.data.clone())
+        lora_down_curr = self._apply_col_scalar(self.lora_down.weight.data.clone())
         pissa_up_init = self.pissa_A_init.to(lora_up_curr.device)
         pissa_down_init = self.pissa_B_init.to(lora_down_curr.device)
 
@@ -872,11 +915,14 @@ class LoConModule(LycorisBaseModule):
         self.lora_down.weight.data = delta_down
         self.lora_dim = 2 * self.lora_dim
 
-        # Reset scalar to 1.0 since it has been absorbed into lora_up
-        if isinstance(self.scalar, nn.Parameter):
-            self.scalar.data.fill_(1.0)
-        else:
-            self.scalar.fill_(1.0)
+        # Reset scalars to 1.0 since they have been absorbed into weights
+        for attr in ("scalar", "row_scalar", "col_scalar"):
+            param = getattr(self, attr, None)
+            if param is not None:
+                if isinstance(param, nn.Parameter):
+                    param.data.fill_(1.0)
+                else:
+                    param.fill_(1.0)
 
         # Restore original weight: W = W^res + A₀B₀
         # The base weight currently holds W^res, so we add back A₀B₀
@@ -904,7 +950,16 @@ class LoConModule(LycorisBaseModule):
 
         scaled = norm != desired
         if scaled:
-            self.scalar *= ratio
+            if self.scalar_type == "scalar":
+                self.scalar *= ratio
+            elif self.scalar_type == "row":
+                self.row_scalar *= ratio
+            elif self.scalar_type == "column":
+                self.col_scalar *= ratio
+            elif self.scalar_type == "row_column":
+                ratio_sqrt = ratio.sqrt()
+                self.row_scalar *= ratio_sqrt
+                self.col_scalar *= ratio_sqrt
             return scaled, orig_norm * ratio
         else:
             return 0, orig_norm
@@ -1039,10 +1094,27 @@ class LoConModule(LycorisBaseModule):
         if self.tucker:
             wc = self._maybe_orthogonalize(self.lora_mid.weight).to(x.device, dtype=x.dtype)
 
-        # Pre-combined scalar to avoid triple multiply inside compiled region
-        combined_scale = self.scalar.to(device=x.device, dtype=x.dtype) * self.scale * scale
-
-        return self._forward_bypass_core(x, wb, wa, wc, combined_scale)
+        if self.scalar_type == "scalar":
+            # Pre-combined scalar to avoid triple multiply inside compiled region
+            combined_scale = self.scalar.to(device=x.device, dtype=x.dtype) * self.scale * scale
+            return self._forward_bypass_core(x, wb, wa, wc, combined_scale)
+        else:
+            # Apply col_scalar to input, row_scalar to output.
+            # Linear features live on the last dim; Conv channels live on dim 1.
+            if self.scalar_type in ("column", "row_column"):
+                cs = self.col_scalar.to(device=x.device, dtype=x.dtype)
+                if self.module_type == "linear":
+                    x = x * cs.view(*([1] * (x.dim() - 1)), -1)
+                else:
+                    x = x * cs.view(1, -1, *([1] * (x.dim() - 2)))
+            out = self._forward_bypass_core(x, wb, wa, wc, self.scale * scale)
+            if self.scalar_type in ("row", "row_column"):
+                rs = self.row_scalar.to(device=out.device, dtype=out.dtype)
+                if self.module_type == "linear":
+                    out = out * rs.view(*([1] * (out.dim() - 1)), -1)
+                else:
+                    out = out * rs.view(1, -1, *([1] * (out.dim() - 2)))
+            return out
 
     def _bypass_forward_diff_multitask(self, x, scale=1):
         """Multi-task O-LoRA bypass forward diff: sum over all task LoRA pairs."""

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -52,6 +52,7 @@ class LohaModule(LycorisBaseModule):
         ggpo_sigma: Optional[float] = None,
         orthogonalize=False,
         orthogonal_init=False,
+        scalar_type: str = "scalar",
         **kwargs,
     ):
         super().__init__(
@@ -155,9 +156,22 @@ class LohaModule(LycorisBaseModule):
         self.register_buffer("alpha", torch.tensor(alpha * (lora_dim / r_factor)))
 
         if use_scalar:
-            init_val = scalar_init_value if scalar_init_value is not None else 0.1
-            self.scalar = nn.Parameter(torch.tensor(init_val))
+            self.scalar_type = scalar_type
+            if scalar_type == "scalar":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.scalar = nn.Parameter(torch.tensor(init_val))
+            elif scalar_type == "row":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.row_scalar = nn.Parameter(torch.full((self.shape[0],), init_val))
+            elif scalar_type == "column":
+                init_val = scalar_init_value if scalar_init_value is not None else 0.1
+                self.col_scalar = nn.Parameter(torch.full((self.shape[1],), init_val))
+            elif scalar_type == "row_column":
+                init_val = scalar_init_value if scalar_init_value is not None else math.sqrt(0.1)
+                self.row_scalar = nn.Parameter(torch.full((self.shape[0],), init_val))
+                self.col_scalar = nn.Parameter(torch.full((self.shape[1],), init_val))
         else:
+            self.scalar_type = "none"
             self.register_buffer("scalar", torch.tensor(1.0), persistent=False)
         # Need more experiments on init method
         if self.use_orthogonal_init:
@@ -262,14 +276,28 @@ class LohaModule(LycorisBaseModule):
         for key in missing_keys:
             if "scalar" in key:
                 del missing_keys[missing_keys.index(key)]
-        if isinstance(self.scalar, nn.Parameter):
-            self.scalar.data.copy_(torch.ones_like(self.scalar))
-        elif getattr(self, "scalar", None) is not None:
-            self.scalar.copy_(torch.ones_like(self.scalar))
-        else:
-            self.register_buffer(
-                "scalar", torch.ones_like(self.scalar), persistent=False
-            )
+        # Reset scalars to 1.0 (baked into weights during save)
+        for attr in ("scalar", "row_scalar", "col_scalar"):
+            param = getattr(self, attr, None)
+            if param is not None:
+                if isinstance(param, nn.Parameter):
+                    param.data.copy_(torch.ones_like(param))
+                else:
+                    param.copy_(torch.ones_like(param))
+
+    def _apply_row_scalar(self, weight):
+        """Bake row scalar into weight for saving. For scalar type, bakes the single scalar."""
+        if self.scalar_type == "scalar":
+            return weight * self.scalar.to(device=weight.device, non_blocking=True)
+        elif self.scalar_type in ("row", "row_column"):
+            return weight * self.row_scalar.to(device=weight.device, non_blocking=True).view(-1, *([1] * (weight.dim() - 1)))
+        return weight
+
+    def _apply_col_scalar(self, weight):
+        """Bake col scalar into weight for saving."""
+        if self.scalar_type in ("column", "row_column"):
+            return weight * self.col_scalar.to(device=weight.device, non_blocking=True).view(1, -1, *([1] * (weight.dim() - 2)))
+        return weight
 
     def get_weight(self, shape):
         scale = torch.tensor(
@@ -361,10 +389,18 @@ class LohaModule(LycorisBaseModule):
         destination["alpha"] = self.alpha
         if self.wd:
             destination["dora_scale"] = self.dora_scale
-        destination["hada_w1_a"] = self.hada_w1_a * self.scalar.to(device=self.hada_w1_a.device, non_blocking=True)
-        destination["hada_w1_b"] = self.hada_w1_b
-        destination["hada_w2_a"] = self.hada_w2_a
-        destination["hada_w2_b"] = self.hada_w2_b
+        if self.scalar_type == "scalar":
+            # Existing behavior: bake scalar into hada_w1_a
+            destination["hada_w1_a"] = self.hada_w1_a * self.scalar.to(device=self.hada_w1_a.device, non_blocking=True)
+            destination["hada_w1_b"] = self.hada_w1_b
+            destination["hada_w2_a"] = self.hada_w2_a
+            destination["hada_w2_b"] = self.hada_w2_b
+        else:
+            # Vector scalars: bake row_scalar into hada_w2_a, col_scalar into hada_w2_b
+            destination["hada_w1_a"] = self.hada_w1_a
+            destination["hada_w1_b"] = self.hada_w1_b
+            destination["hada_w2_a"] = self._apply_row_scalar(self.hada_w2_a)
+            destination["hada_w2_b"] = self._apply_col_scalar(self.hada_w2_b)
         if self.tucker:
             destination["hada_t1"] = self.hada_t1
             destination["hada_t2"] = self.hada_t2
@@ -372,14 +408,23 @@ class LohaModule(LycorisBaseModule):
 
     @torch.no_grad()
     def apply_max_norm(self, max_norm, device=None):
-        orig_norm = (self.get_weight(self.shape) * self.scalar).norm()
+        orig_norm = self.get_weight(self.shape).norm()
         norm = torch.clamp(orig_norm, max_norm / 2)
         desired = torch.clamp(norm, max=max_norm)
         ratio = desired.cpu() / norm.cpu()
 
         scaled = norm != desired
         if scaled:
-            self.scalar *= ratio
+            if self.scalar_type == "scalar":
+                self.scalar *= ratio
+            elif self.scalar_type == "row":
+                self.row_scalar *= ratio
+            elif self.scalar_type == "column":
+                self.col_scalar *= ratio
+            elif self.scalar_type == "row_column":
+                ratio_sqrt = ratio.sqrt()
+                self.row_scalar *= ratio_sqrt
+                self.col_scalar *= ratio_sqrt
             return scaled, orig_norm * ratio
         else:
             return 0, orig_norm
@@ -392,7 +437,21 @@ class LohaModule(LycorisBaseModule):
         return unscaled_norm
 
     def bypass_forward_diff(self, x, scale=1):
-        diff_weight = self.get_weight(self.shape) * self.scalar * scale
+        diff_weight = self.get_weight(self.shape)
+        if self.scalar_type == "scalar":
+            diff_weight = diff_weight * self.scalar * scale
+        elif self.scalar_type == "row":
+            rs = self.row_scalar.view(-1, *([1] * (diff_weight.dim() - 1)))
+            diff_weight = diff_weight * rs * scale
+        elif self.scalar_type == "column":
+            cs = self.col_scalar.view(1, -1, *([1] * (diff_weight.dim() - 2)))
+            diff_weight = diff_weight * cs * scale
+        elif self.scalar_type == "row_column":
+            rs = self.row_scalar.view(-1, *([1] * (diff_weight.dim() - 1)))
+            cs = self.col_scalar.view(1, -1, *([1] * (diff_weight.dim() - 2)))
+            diff_weight = diff_weight * rs * cs * scale
+        else:
+            diff_weight = diff_weight * scale
         return self.drop(self._call_op(x, diff_weight))
 
     def bypass_forward(self, x, scale=1):
@@ -405,7 +464,17 @@ class LohaModule(LycorisBaseModule):
         merges with the pre-fetched original weight, and runs the fused
         linear/conv operation.  All inputs are pre-fetched GPU tensors.
         """
-        diff_weight = self.get_weight(self.shape).to(self._cached_dtype) * self.scalar
+        diff_weight = self.get_weight(self.shape).to(self._cached_dtype)
+        if self.scalar_type == "scalar":
+            diff_weight = diff_weight * self.scalar
+        elif self.scalar_type == "row":
+            diff_weight = diff_weight * self.row_scalar.view(-1, *([1] * (diff_weight.dim() - 1)))
+        elif self.scalar_type == "column":
+            diff_weight = diff_weight * self.col_scalar.view(1, -1, *([1] * (diff_weight.dim() - 2)))
+        elif self.scalar_type == "row_column":
+            r = self.row_scalar.view(-1, *([1] * (diff_weight.dim() - 1)))
+            c = self.col_scalar.view(1, -1, *([1] * (diff_weight.dim() - 2)))
+            diff_weight = diff_weight * r * c
         weight = org_weight
         multiplier = self.multiplier_buf
         if self.wd:

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -70,6 +70,7 @@ class LokrModule(LycorisBaseModule):
         ggpo_sigma: Optional[float] = None,
         orthogonalize=False,
         orthogonal_init=False,
+        scalar_type: str = "scalar",
         **kwargs,
     ):
         super().__init__(
@@ -234,6 +235,14 @@ class LokrModule(LycorisBaseModule):
         self.scale = alpha / r_factor
 
         self.register_buffer("alpha", torch.tensor(alpha * (lora_dim / r_factor)))
+
+        # LoKr: vector scalar modes not supported due to Kronecker structure
+        if use_scalar and scalar_type in ("row", "column", "row_column"):
+            logger.warning(
+                f"LoKr: scalar_type='{scalar_type}' is not supported due to Kronecker structure. "
+                f"Falling back to scalar_type='scalar'."
+            )
+            scalar_type = "scalar"
 
         if use_scalar:
             init_val = scalar_init_value if scalar_init_value is not None else 0.1

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -118,6 +118,12 @@ def create_lycoris(module, multiplier=1.0, linear_dim=4, linear_alpha=1, **kwarg
     scalar_init_value = kwargs.get("scalar_init_value", None)
     if scalar_init_value is not None:
         scalar_init_value = float(scalar_init_value)
+    scalar_type = kwargs.get("scalar_type", "scalar")
+    if scalar_type not in ("scalar", "row", "column", "row_column"):
+        raise ValueError(
+            f"Invalid scalar_type='{scalar_type}', must be one of: "
+            f"scalar, row, column, row_column"
+        )
     block_size = int(kwargs.get("block_size", 4) or 4)
     train_norm = str_bool(kwargs.get("train_norm", False))
     constraint = float(kwargs.get("constraint", 0) or 0)
@@ -285,6 +291,7 @@ def create_lycoris(module, multiplier=1.0, linear_dim=4, linear_alpha=1, **kwarg
                 "use_scalar set to False."
             )
             use_scalar = False
+            scalar_type = "scalar"
 
     # RaLoRA parameters
     ralora_n_max = int(kwargs.get("ralora_n_max", 32))
@@ -334,6 +341,7 @@ def create_lycoris(module, multiplier=1.0, linear_dim=4, linear_alpha=1, **kwarg
                 "use_scalar set to False."
             )
             use_scalar = False
+            scalar_type = "scalar"
 
     # TSM parameters
     tsm_n_scales = kwargs.get("tsm_n_scales", None)
@@ -410,6 +418,7 @@ def create_lycoris(module, multiplier=1.0, linear_dim=4, linear_alpha=1, **kwarg
         use_tucker=use_tucker,
         use_scalar=use_scalar,
         scalar_init_value=scalar_init_value,
+        scalar_type=scalar_type,
         network_module=algo,
         train_norm=train_norm,
         decompose_both=kwargs.get("decompose_both", False),

--- a/test/module.py
+++ b/test/module.py
@@ -344,3 +344,120 @@ class LycorisModuleTests(unittest.TestCase):
                 elif hasattr(net, "hada_w1_a"):
                     self.assertIsNotNone(net.hada_w1_a.grad)
                 net.restore()
+
+    # --- Vector scalar_type tests ---
+
+    _scalar_type_modules = [LoConModule, LohaModule]
+
+    def test_scalar_type_parameter_creation(self):
+        """scalar_type should create correct parameter shapes."""
+        base = nn.Linear(16, 16)
+        scalar_types = ["scalar", "row", "column", "row_column"]
+        for module_cls in self._scalar_type_modules:
+            for st in scalar_types:
+                net = module_cls(
+                    "test", base, multiplier=1, lora_dim=4, alpha=1,
+                    use_scalar=True, scalar_type=st,
+                )
+                if st == "scalar":
+                    self.assertIsInstance(net.scalar, nn.Parameter)
+                    self.assertEqual(net.scalar.shape, ())
+                elif st == "row":
+                    self.assertIsInstance(net.row_scalar, nn.Parameter)
+                    self.assertEqual(net.row_scalar.shape, (16,))
+                    self.assertFalse(hasattr(net, "col_scalar"))
+                elif st == "column":
+                    self.assertIsInstance(net.col_scalar, nn.Parameter)
+                    self.assertEqual(net.col_scalar.shape, (16,))
+                    self.assertFalse(hasattr(net, "row_scalar"))
+                elif st == "row_column":
+                    self.assertIsInstance(net.row_scalar, nn.Parameter)
+                    self.assertIsInstance(net.col_scalar, nn.Parameter)
+                    self.assertEqual(net.row_scalar.shape, (16,))
+                    self.assertEqual(net.col_scalar.shape, (16,))
+                net.restore()
+
+    def test_scalar_type_forward_consistency(self):
+        """Rebuild and bypass forward should produce same output for each scalar_type."""
+        base = nn.Linear(16, 16)
+        test_input = torch.randn(1, 16)
+        scalar_types = ["scalar", "row", "column", "row_column"]
+        for module_cls in self._scalar_type_modules:
+            for st in scalar_types:
+                net = module_cls(
+                    "test", base, multiplier=1, lora_dim=4, alpha=1,
+                    use_scalar=True, scalar_type=st, bypass_mode=False,
+                )
+                net.apply_to()
+
+                # Get rebuild output
+                with torch.no_grad():
+                    out_r = base(test_input.clone())
+
+                # Switch to bypass mode
+                net.bypass_mode = True
+
+                with torch.no_grad():
+                    out_b = base(test_input.clone())
+
+                self.assertTrue(
+                    torch.allclose(out_r, out_b, atol=1e-4),
+                    f"{module_cls.__name__} scalar_type={st}: rebuild vs bypass mismatch"
+                )
+                net.restore()
+
+    def test_scalar_type_save_load_roundtrip(self):
+        """Scalars should be baked into weights on save and reset to 1.0 on load."""
+        base = nn.Linear(16, 16)
+        scalar_types = ["scalar", "row", "column", "row_column"]
+        for module_cls in self._scalar_type_modules:
+            for st in scalar_types:
+                net = module_cls(
+                    "test", base, multiplier=1, lora_dim=4, alpha=1,
+                    use_scalar=True, scalar_type=st,
+                )
+                net.apply_to()
+
+                # Get state dict (scalars should be baked in)
+                state_dict = net.state_dict()
+
+                # Verify scalar keys are NOT in state dict
+                for key in state_dict:
+                    self.assertNotIn("scalar", key,
+                        f"scalar key '{key}' should not appear in state dict")
+
+                net.restore()
+
+    def test_scalar_type_backward_compat(self):
+        """scalar_type='scalar' should produce identical parameter shapes to use_scalar=True."""
+        base = nn.Linear(16, 16)
+        for module_cls in self._scalar_type_modules:
+            # Default (no scalar_type)
+            net1 = module_cls(
+                "test", base, multiplier=1, lora_dim=4, alpha=1,
+                use_scalar=True,
+            )
+            # Explicit scalar_type="scalar"
+            net2 = module_cls(
+                "test", base, multiplier=1, lora_dim=4, alpha=1,
+                use_scalar=True, scalar_type="scalar",
+            )
+            # Both should have scalar as nn.Parameter
+            self.assertIsInstance(net1.scalar, nn.Parameter)
+            self.assertIsInstance(net2.scalar, nn.Parameter)
+            self.assertEqual(net1.scalar.shape, net2.scalar.shape)
+            net1.restore()
+            net2.restore()
+
+    def test_lokr_scalar_type_fallback(self):
+        """LoKr should fall back to scalar_type='scalar' for vector modes."""
+        base = nn.Linear(16, 16)
+        vector_types = ["row", "column", "row_column"]
+        for st in vector_types:
+            net = LokrModule(
+                "test", base, multiplier=1, lora_dim=4, alpha=1,
+                use_scalar=True, scalar_type=st,
+            )
+            # Should have fallen back to scalar
+            self.assertIsInstance(net.scalar, nn.Parameter)
+            net.restore()


### PR DESCRIPTION
Extends use_scalar to support vector scalars (row-wise, column-wise, both row & column-wise). 
Allows for more granular 'scalars' that are invisible to inference pipelines. 
`scalar_type=row_column` is likely very useful with orthogonalize=True, as it allows for non-uniform singular values in the LoRA matrices.